### PR TITLE
Allow multiple template directories

### DIFF
--- a/src/Dotnet.CodeGen/CodeGenRunner.cs
+++ b/src/Dotnet.CodeGen/CodeGenRunner.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -10,18 +11,64 @@ namespace Dotnet.CodeGen.CodeGen
 {
     public class CodeGenRunner
     {
-        public static async Task RunAsync(string sourcePath, ISchemaLoader schemaLoader, string templatePath, string outputPath)
+        private static IEnumerable<TemplateInfos> ConsolidateTemplates(IGrouping<string,TemplateInfos>[] templateInfos, IGrouping<string, TemplateInfos>[] duplicateTemplateInfos, TemplateDuplicationHandlingStrategy templateDuplicationHandlingStrategy)
+        {
+            switch (templateDuplicationHandlingStrategy)
+            {
+                case TemplateDuplicationHandlingStrategy.Throw:
+                    
+                    throw new InvalidDataException("Possible template(s) duplication - please use a unique template name [" + duplicateTemplateInfos.Select(templateGroup => templateGroup.Key).Aggregate((template1, template2) => $"{template1} | {template2}" + "]"));
+               
+                case TemplateDuplicationHandlingStrategy.KeepFirst:
+
+                    foreach (var templateGroup in templateInfos)
+                    {
+                        yield return templateGroup.First();
+                    }
+
+                    break;
+                case TemplateDuplicationHandlingStrategy.KeepLast:
+
+                    foreach (var templateGroup in templateInfos)
+                    {
+                        yield return templateGroup.Last();
+                    }
+
+                    break;
+            }
+        }
+
+        public static IEnumerable<TemplateInfos> GetTemplates(List<string> templatesPaths, TemplateDuplicationHandlingStrategy templateDuplicationHandlingStrategy)
+        {
+            var templates = templatesPaths.SelectMany(templatePath => TemplateHelper.GetTemplates(templatePath, "*.hbs").Where(t => !t.FileName.StartsWith("_")))
+                                          .ToArray();
+
+            if (templates.Length == 0)
+                throw new InvalidDataException("No template found in path(s) " + templatesPaths.Aggregate((path1, path2) => $"{path1} | {path2}"));
+
+            var templateGroups = templates.GroupBy(template => template.FileName)
+                                          .ToArray();
+
+            var templatesGroupDuplicates = templateGroups.Where(group => group.Count() > 1).ToArray();
+
+            if (templatesGroupDuplicates.Length == 0) return templates;
+
+
+            return ConsolidateTemplates(templateGroups, templatesGroupDuplicates, templateDuplicationHandlingStrategy);
+        }  
+
+        public static Task RunAsync(string sourcePath, ISchemaLoader schemaLoader, string templatePath, string outputPath, TemplateDuplicationHandlingStrategy templateDuplicationHandlingStrategy = TemplateDuplicationHandlingStrategy.Throw)
+        {
+            return RunAsync(sourcePath, schemaLoader, new List<string>() { templatePath }, outputPath);
+        }
+
+        public static async Task RunAsync(string sourcePath, ISchemaLoader schemaLoader, List<string> templatesPaths, string outputPath, TemplateDuplicationHandlingStrategy templateDuplicationHandlingStrategy = TemplateDuplicationHandlingStrategy.Throw)
         {
             var jsonObject = schemaLoader.LoadSchema(sourcePath);
 
-            var templates = TemplateHelper.GetTemplates(templatePath, "*.hbs")
-                .Where(t => !t.FileName.StartsWith("_"))
-                .ToArray();
+            var templates = GetTemplates(templatesPaths, templateDuplicationHandlingStrategy);
 
-            if (templatePath.Length == 0)
-                throw new InvalidDataException($"No template found in {templatePath}.");
-
-            var handlebars = HandlebarsConfigurationHelper.GetHandlebars(templatePath);
+            var handlebars = HandlebarsConfigurationHelper.GetHandlebars(templatesPaths);
 
             foreach (var template in templates)
             {
@@ -31,14 +78,13 @@ namespace Dotnet.CodeGen.CodeGen
 
                 var context = new ProcessorContext { InputFile = result, OutputDirectory = outputPath, };
 
-                using (var processor = new FilesProcessor(context,
+                using var processor = new FilesProcessor(context,
                     new WriteLineToFileInstruction("FILE"),
                     new WriteLineToConsoleInstruction("CONSOLE"),
                     new SuppressLineInstruction()
-                    ))
-                {
-                    await processor.RunAsync();
-                }
+                    );
+
+                await processor.RunAsync();
             }
         }
     }

--- a/src/Dotnet.CodeGen/Dotnet.CodeGen.csproj
+++ b/src/Dotnet.CodeGen/Dotnet.CodeGen.csproj
@@ -23,6 +23,10 @@
     <RepositoryUrl>https://github.com/BeezUP/dotnet-codegen.git</RepositoryUrl>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Colorful.Console" Version="1.2.9" />
     <PackageReference Include="Handlebars.Net" Version="1.10.1" />

--- a/src/Dotnet.CodeGen/Program.cs
+++ b/src/Dotnet.CodeGen/Program.cs
@@ -8,46 +8,57 @@ using Console = Colorful.Console;
 
 namespace Dotnet.CodeGen.CodeGen
 {
-    class Program
+    public class Program
     {
         public static readonly Color ERROR_COLOR = Color.OrangeRed;
 
         public const string SOURCE_FILE_ARGUMENT = "source";
-        public const string TEMPLATE_PATH_ARGUMENT = "template";
         public const string OUTPUT_PATH_ARGUMENT = "out";
+        public const string TEMPLATES_PATH_ARGUMENT = "templates";
+        
+        public const string TEMPLATE_DUPLICATES_HANDLING_STRATEGY_OPTION = "-d|--duplicates";
+        public const string SCHEMA_TYPE_OPTION = "-s|--type";
+        private const string HelpOptions = "-? |-h|--help";
 
-        public const string SCHEMA_TYPE_OPTION = "--type";
-        private const string HelpOptions = "-? | -h | --help";
-
-        static async Task Main(string[] args)
+        public static async Task Main(string[] args)
         {
             //https://msdn.microsoft.com/fr-fr/magazine/mt763239.aspx
             var app = new CommandLineApplication();
             app.HelpOption(HelpOptions);
 
-            var sourceFile = app.Argument(SOURCE_FILE_ARGUMENT, "Enter the path (relative or absolute) to an source document.");
-            var templatePath = app.Argument(TEMPLATE_PATH_ARGUMENT, "Enter the path (relative or absolute / single file or folder) to the template.");
-            var outputPath = app.Argument(OUTPUT_PATH_ARGUMENT, "Enter the path (relative or absolute) to the output path (content will be overritten)");
             var schemaTypeName = app.Option(SCHEMA_TYPE_OPTION, $"Enter a schema type between those values [{string.Join(" | ", Enum.GetNames(typeof(SourceSchemaType)))}]", CommandOptionType.SingleValue);
+            var duplicatesTemplateHandlingStrategyName = app.Option(TEMPLATE_DUPLICATES_HANDLING_STRATEGY_OPTION, $"Enter a template duplication handling strategy between those values [{string.Join(" | ", Enum.GetNames(typeof(TemplateDuplicationHandlingStrategy)))}]", CommandOptionType.SingleValue);
 
+            var sourceFile = app.Argument(SOURCE_FILE_ARGUMENT, "Enter the path (relative or absolute) to an source document.");
+            var outputPath = app.Argument(OUTPUT_PATH_ARGUMENT, "Enter the path (relative or absolute) to the output path (content will be overritten)");
+            var templatesPaths = app.Argument(TEMPLATES_PATH_ARGUMENT, "Enter the path(s) (relative or absolute / multiple files or folders) to the template(s).", multipleValues: true);
 
             app.OnExecute(async () =>
             {
                 var errors = new List<string>();
                 if (sourceFile.Value == null)
                     errors.Add($"{SOURCE_FILE_ARGUMENT} parameter is required");
-                if (templatePath.Value == null)
-                    errors.Add($"{TEMPLATE_PATH_ARGUMENT} parameter is required");
+                if (templatesPaths.Values == null || templatesPaths.Values.Count == 0)
+                    errors.Add($"{TEMPLATES_PATH_ARGUMENT} parameter is required");
                 if (outputPath.Value == null)
                     errors.Add($"{OUTPUT_PATH_ARGUMENT} parameter is required");
 
                 var schemaType = SchemaTypeExtensions.DEFAULT_SHEMA_TYPE;
                 if (schemaTypeName.HasValue())
                 {
-                    if (Enum.TryParse<SourceSchemaType>(schemaTypeName.Value(), out var s))
-                        schemaType = s;
+                    if (Enum.TryParse<SourceSchemaType>(schemaTypeName.Value(), out var schema))
+                        schemaType = schema;
                     else
                         errors.Add($"The schema type '{schemaTypeName.Value()}' is unknown.");
+                }
+
+                var duplicatesTemplateHandlingStrategy = TemplateDuplicationHandlingStrategy.Throw;
+                if (duplicatesTemplateHandlingStrategyName.HasValue())
+                {
+                    if (Enum.TryParse<TemplateDuplicationHandlingStrategy>(duplicatesTemplateHandlingStrategyName.Value(), out var strategy))
+                        duplicatesTemplateHandlingStrategy = strategy;
+                    else
+                        errors.Add($"The duplicates template handling strategy type '{duplicatesTemplateHandlingStrategyName.Value()}' is unknown.");
                 }
 
                 if (errors.Count != 0)
@@ -59,20 +70,26 @@ namespace Dotnet.CodeGen.CodeGen
                 }
 
                 var schemaLoader = schemaType.GetSchemaLoader();
-                await CodeGenRunner.RunAsync(sourceFile.Value, schemaLoader, templatePath.Value, outputPath.Value);
+                await CodeGenRunner.RunAsync(sourceFile.Value, schemaLoader, templatesPaths.Values, outputPath.Value, duplicatesTemplateHandlingStrategy);
 
                 return 0;
             });
 
             try
-            {   
+            {
                 var result = app.Execute(args);
-                Environment.Exit(result);
+#if (!DEBUG)
+                 Environment.Exit(result);
+#endif
+
+
             }
             catch (Exception ex)
             {
                 Console.Error.WriteLine(ex.Message);
+#if (!DEBUG)
                 Environment.Exit(1);
+#endif
             }
         }
     }

--- a/src/Dotnet.CodeGen/TemplateHelper.cs
+++ b/src/Dotnet.CodeGen/TemplateHelper.cs
@@ -8,30 +8,6 @@ namespace Dotnet.CodeGen.CodeGen
 {
     public static class TemplateHelper
     {
-        public class TemplateInfos
-        {
-            internal TemplateInfos(string filePath, string fileName, string directory)
-            {
-                FilePath = filePath;
-                FileName = fileName;
-                Directory = directory;
-            }
-
-            /// <summary>
-            /// Full path of the file
-            /// </summary>
-            public string FilePath { get; }
-
-            /// <summary>
-            /// Expected file name (without the template extension)
-            /// </summary>
-            public string FileName { get; }
-
-            /// <summary>
-            /// Expected relative directory (from the template root)
-            /// </summary>
-            public string Directory { get; }
-        }
 
         public static IEnumerable<TemplateInfos> GetTemplates(string path, string extension = "*.handlebars")
         {

--- a/src/Dotnet.CodeGen/TemplateInfos.cs
+++ b/src/Dotnet.CodeGen/TemplateInfos.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Dotnet.CodeGen
+{
+    public class TemplateInfos
+    {
+        internal TemplateInfos(string filePath, string fileName, string directory)
+        {
+            FilePath = filePath;
+            FileName = fileName;
+            Directory = directory;
+        }
+
+        /// <summary>
+        /// Full path of the file
+        /// </summary>
+        public string FilePath { get; }
+
+        /// <summary>
+        /// Expected file name (without the template extension)
+        /// </summary>
+        public string FileName { get; }
+
+        /// <summary>
+        /// Expected relative directory (from the template root)
+        /// </summary>
+        public string Directory { get; }
+
+        public override int GetHashCode()
+        {
+            return FilePath.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is TemplateInfos)) return false;
+
+            return obj.GetHashCode() == GetHashCode();
+        }
+    }
+
+}

--- a/src/Dotnet.CodeGen/TemplateOverrideStrategy.cs
+++ b/src/Dotnet.CodeGen/TemplateOverrideStrategy.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Dotnet.CodeGen
+{
+    public enum TemplateDuplicationHandlingStrategy
+    {
+        Throw,
+        KeepLast,
+        KeepFirst
+    }
+}

--- a/tests/Dotnet.CodeGen.Tests/CodeGenRunnerTests.cs
+++ b/tests/Dotnet.CodeGen.Tests/CodeGenRunnerTests.cs
@@ -21,15 +21,18 @@ namespace Dotnet.CodeGen.Tests
         }
 
         [Theory]
-        [InlineData(SourceSchemaType.RawJson, "./_samples/test1/schema.json", "./_samples/test1/template", "./_samples/test1/expected")]
-        public async Task OpenApiTemplates(SourceSchemaType schemaType, string schemaPath, string templatePath, string expectedResultPath)
+        [InlineData(SourceSchemaType.RawJson, "./_samples/test3/sample_swagger.json", new[] { "./_samples/test3/template1/path1.hbs", "./_samples/test3/template2/path2.hbs" }, "./_samples/test3/expected")]
+        [InlineData(SourceSchemaType.RawJson, "./_samples/test3/sample_swagger.json", new[] { "./_samples/test3/template1/path1.hbs", "./_samples/test3/template2" }, "./_samples/test3/expected")]
+        [InlineData(SourceSchemaType.RawJson, "./_samples/test3/sample_swagger.json", new[] { "./_samples/test3/template1", "./_samples/test3/template2" }, "./_samples/test3/expected")]
+        [InlineData(SourceSchemaType.RawJson, "./_samples/test1/schema.json", new[] { "./_samples/test1/template" }, "./_samples/test1/expected")]
+        public async Task ShouldGetAndApplyOpenApiTemplates(SourceSchemaType schemaType, string schemaPath, string[] templatesPaths, string expectedResultPath)
         {
             var tmpFolder = Path.GetRandomFileName();
             try
             {
                 var loader = schemaType.GetSchemaLoader();
 
-                await CodeGenRunner.RunAsync(schemaPath, loader, templatePath, tmpFolder);
+                await CodeGenRunner.RunAsync(schemaPath, loader, templatesPaths.ToList(), tmpFolder);
 
                 var expectedFiles = Directory.GetFiles(expectedResultPath, "*.*", SearchOption.AllDirectories).ToArray();
                 var resultFiles = Directory.GetFiles(tmpFolder, "*.*", SearchOption.AllDirectories).ToArray();
@@ -58,5 +61,62 @@ namespace Dotnet.CodeGen.Tests
                     Directory.Delete(tmpFolder, true);
             }
         }
+
+        [Theory]
+        [InlineData(new[] { "./_samples/test4/template1", "./_samples/test4/template2" }, TemplateDuplicationHandlingStrategy.Throw)]
+        [InlineData(new[] { "./_samples/test4/template3", "./_samples/test4/template4" }, TemplateDuplicationHandlingStrategy.Throw)]
+        public void ShouldThrowExceptionOnConsolidateTemplates(string[] templatesPaths, TemplateDuplicationHandlingStrategy templateDuplicationHandlingStrategy)
+        {
+            Assert.Throws<InvalidDataException>(() =>
+            {
+                CodeGenRunner.GetTemplates(templatesPaths.ToList(), templateDuplicationHandlingStrategy).ToList();
+            });
+        }
+
+        [Theory]
+        [InlineData(new[] { "./_samples/test4/template1", "./_samples/test4/template3" }, TemplateDuplicationHandlingStrategy.Throw)]
+        [InlineData(new[] { "./_samples/test4/template2", "./_samples/test4/template4" }, TemplateDuplicationHandlingStrategy.Throw)]
+        public void ShouldNotThrowExceptionOnConsolidateTemplates(string[] templatesPaths, TemplateDuplicationHandlingStrategy templateDuplicationHandlingStrategy)
+        {
+            var templates = CodeGenRunner.GetTemplates(templatesPaths.ToList(), templateDuplicationHandlingStrategy).ToList();
+
+            Assert.Equal(4, templates.Count);
+
+            Assert.Contains(templates, template => template.FileName == "path1");
+            Assert.Contains(templates, template => template.FileName == "path2");
+            Assert.Contains(templates, template => template.FileName == "path3");
+            Assert.Contains(templates, template => template.FileName == "path4");
+        }
+
+        [Theory]
+        [InlineData(new[] { "./_samples/test4/template1", "./_samples/test4/template2" }, "template1", TemplateDuplicationHandlingStrategy.KeepFirst)]
+        [InlineData(new[] { "./_samples/test4/template3", "./_samples/test4/template4" }, "template3", TemplateDuplicationHandlingStrategy.KeepFirst)]
+        public void ShouldKeepFirstTemplatesOnDuplicatesOnConsolidateTemplates(string[] templatesPaths, string expectedTemplateFolder, TemplateDuplicationHandlingStrategy templateDuplicationHandlingStrategy)
+        {
+            var templates = CodeGenRunner.GetTemplates(templatesPaths.ToList(), templateDuplicationHandlingStrategy).ToList();
+
+            Assert.Equal(2, templates.Count);
+
+            foreach(var template in templates)
+            {
+                Assert.Contains(expectedTemplateFolder, template.FilePath);
+            }
+        }
+
+        [Theory]
+        [InlineData(new[] { "./_samples/test4/template1", "./_samples/test4/template2" }, "template2", TemplateDuplicationHandlingStrategy.KeepLast)]
+        [InlineData(new[] { "./_samples/test4/template3", "./_samples/test4/template4" }, "template4", TemplateDuplicationHandlingStrategy.KeepLast)]
+        public void ShouldKeepLastTemplatesOnDuplicatesOnConsolidateTemplates(string[] templatesPaths, string expectedTemplateFolder, TemplateDuplicationHandlingStrategy templateDuplicationHandlingStrategy)
+        {
+            var templates = CodeGenRunner.GetTemplates(templatesPaths.ToList(), templateDuplicationHandlingStrategy).ToList();
+
+            Assert.Equal(2, templates.Count);
+
+            foreach (var template in templates)
+            {
+                Assert.Contains(expectedTemplateFolder, template.FilePath);
+            }
+        }
+
     }
 }

--- a/tests/Dotnet.CodeGen.Tests/Dotnet.CodeGen.Tests.csproj
+++ b/tests/Dotnet.CodeGen.Tests/Dotnet.CodeGen.Tests.csproj
@@ -6,6 +6,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="Shouldly" Version="3.0.2" />
@@ -29,7 +33,21 @@
     <Compile Remove="_samples\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Remove="_samples\test3\sample_swagger.json" />
+    <None Remove="_samples\test3\template1\path1.hbs" />
+    <None Remove="_samples\test3\template2\path2.hbs" />
+    <None Remove="_samples\test4\template1\path1.hbs" />
+    <None Remove="_samples\test4\template1\path2.hbs" />
+    <None Remove="_samples\test4\template1\path3.hbs" />
+    <None Remove="_samples\test4\template2\path1.hbs" />
+    <None Remove="_samples\test4\template2\path2.hbs" />
+    <None Remove="_samples\test4\template3\path4.hbs" />
+    <None Remove="_samples\test4\template4\path3.hbs" />
+    <None Remove="_samples\test4\template4\path4.hbs" />
+  </ItemGroup>
+  <ItemGroup>
     <Folder Include="Schemas\" />
+    <Folder Include="_samples\test3\expected\" />
   </ItemGroup>
 
 </Project>

--- a/tests/Dotnet.CodeGen.Tests/IgnoreLinuxFact.cs
+++ b/tests/Dotnet.CodeGen.Tests/IgnoreLinuxFact.cs
@@ -16,4 +16,15 @@ namespace Dotnet.CodeGen.Tests
             }
         }
     }
+
+    public sealed class IgnoreOnLinuxTheory : TheoryAttribute
+    {
+        public IgnoreOnLinuxTheory()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                Skip = "Ignore on Linux";
+            }
+        }
+    }
 }

--- a/tests/Dotnet.CodeGen.Tests/ProgramTests.cs
+++ b/tests/Dotnet.CodeGen.Tests/ProgramTests.cs
@@ -1,0 +1,73 @@
+﻿using Dotnet.CodeGen.CodeGen;
+using Dotnet.CodeGen.Schemas;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Dotnet.CodeGen.Tests
+{
+    public class ProgramTests
+    {
+        //https://stackoverflow.com/questions/10520048/calculate-md5-checksum-for-a-file
+        static string CalculateMD5(string filename)
+        {
+            using (var md5 = MD5.Create())
+            {
+                using (var stream = File.OpenRead(filename))
+                {
+                    var hash = md5.ComputeHash(stream);
+                    return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+                }
+            }
+        }
+
+        //https://stackoverflow.com/questions/278439/creating-a-temporary-directory-in-windows
+        static string GetTemporaryDirectory()
+        {
+            var tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            Directory.CreateDirectory(tempDirectory);
+            return tempDirectory;
+        }
+
+        [IgnoreOnLinuxTheory]
+        [InlineData("./_samples/test1/schema.json", new[] { "./_samples/test1/template/test.hbs" }, "./_samples/test1/expected", TemplateDuplicationHandlingStrategy.KeepLast, SourceSchemaType.RawJson)]
+        [InlineData("./_samples/test3/sample_swagger.json", new[] { "./_samples/test3/template1/path1.hbs", "./_samples/test3/template2/path2.hbs" }, "./_samples/test3/expected", TemplateDuplicationHandlingStrategy.KeepLast, SourceSchemaType.RawJson)]
+        public async Task ShouldParseCommandLineArgumentsAndApplyTemplate(string source, string[] templates, string expectedDirectory, TemplateDuplicationHandlingStrategy templateDuplicationHandlingStrategy, SourceSchemaType sourceSchemaType)
+        {
+
+            var expectedMd5Output = Directory.GetFiles(expectedDirectory).Select(file => CalculateMD5(file)).ToList();
+
+            var templateDuplicationHandlingStrategyOption = $" {templateDuplicationHandlingStrategy}";
+            var sourceSchemaTypeOption = $" {sourceSchemaType}";
+
+            var outputDirectory = GetTemporaryDirectory();
+
+            try
+            {
+                var args = new[] { "-s", sourceSchemaTypeOption, "-d", templateDuplicationHandlingStrategyOption, source, outputDirectory }.Concat(templates).ToArray();
+
+                await Program.Main(args);
+
+                var actualMd5Output = Directory.GetFiles(outputDirectory).Select(file => CalculateMD5(file)).ToList();
+
+                Assert.Equal(expectedMd5Output.Count, actualMd5Output.Count);
+
+                foreach (var expectedMd5 in expectedMd5Output)
+                {
+                    Assert.Contains(expectedMd5, actualMd5Output);
+                }
+
+            }
+            finally
+            {
+                Directory.Delete(outputDirectory, true);
+            }
+
+        }
+    }
+}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test1/expected/test1.txt
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test1/expected/test1.txt
@@ -1,1 +1,1 @@
-﻿content1
+content1

--- a/tests/Dotnet.CodeGen.Tests/_samples/test1/expected/test2.csv
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test1/expected/test2.csv
@@ -1,1 +1,1 @@
-﻿content2; content3
+content2; content3

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/complete_path1.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/complete_path1.cs
@@ -1,0 +1,1 @@
+//complete_path1

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/complete_paths2.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/complete_paths2.cs
@@ -1,0 +1,1 @@
+//complete_path2

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/errorReporting_path1.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/errorReporting_path1.cs
@@ -1,0 +1,1 @@
+//errorReporting_path1

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/errorReporting_paths2.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/errorReporting_paths2.cs
@@ -1,0 +1,1 @@
+//errorReporting_path2

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/events_path1.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/events_path1.cs
@@ -1,0 +1,1 @@
+//events_path1

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/events_paths2.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/events_paths2.cs
@@ -1,0 +1,1 @@
+//events_path2

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/ping_path1.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/ping_path1.cs
@@ -1,0 +1,1 @@
+//ping_path1

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/ping_paths2.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/ping_paths2.cs
@@ -1,0 +1,1 @@
+//ping_path2

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/start_path1.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/start_path1.cs
@@ -1,0 +1,1 @@
+//start_path1

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/start_paths2.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/start_paths2.cs
@@ -1,0 +1,1 @@
+//start_path2

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/status_path1.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/status_path1.cs
@@ -1,0 +1,1 @@
+//status_path1

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/status_paths2.cs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/expected/status_paths2.cs
@@ -1,0 +1,1 @@
+//status_path2

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/sample_swagger.json
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/sample_swagger.json
@@ -1,0 +1,1712 @@
+﻿{
+  "swagger": "2.0",
+    "info": {
+        "title": "Marketplace Gateway API - Feeds",
+        "description": "This API has to be implemented by the marketplace to be compatible with BeezUP.",
+        "version": "1.0",
+        "x-logo": {
+            "url": "https://avatars0.githubusercontent.com/u/25665430",
+            "backgroundColor": "#FFFFFF"
+        },
+        "contact": {
+            "email": "help@beezup.com"
+        },
+        "license": {
+            "name": "BeezUP",
+            "url": "http://www.beezup.com"
+        }
+    },
+  "host": "mkpapigateway.beezup.com",
+  "basePath": "/marketplace/feeds/v1",
+  "x-beezup-ops": {
+    "codeGenType": "webapi",
+    "repo": "BeezUP",
+    "product": "BeezUP",
+    "group": "adpt-feedpub",
+    "applicationShortName": "MKP.ADPT.Feeds.WS",
+    "appRoot": "BZ.MKP.ADPT.Feeds.WebService",
+    "namespace": "BZ.MKP.ADPT.Feeds.WebService",
+    "apiName": "MkpGatewayOffersV1",
+    "useBeezUPFrameworkVersion2": "true",
+    "comment": "First document\n",
+    "using": [
+      "BeezUP2.Framework.Messaging",
+      "BeezUP2.Framework.Business"
+    ],
+    "packages": [
+      "BeezUPWebApi"
+    ]
+  },
+  "x-basePath": "/marketplace/feeds/v1",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "tags": [
+    {
+      "name": "Publication"
+    }
+  ],
+  "parameters": {
+    "marketplaceBusinessCodeParameter": {
+      "name": "marketplaceBusinessCode",
+      "in": "path",
+      "required": "true",
+      "type": "string"
+    },
+    "accountIdParameter": {
+      "name": "accountId",
+      "in": "path",
+      "required": "true",
+      "type": "integer"
+    },
+    "publicationIdParameter": {
+      "name": "publicationId",
+      "in": "path",
+      "required": "true",
+      "type": "string",
+      "format": "guid"
+    },
+    "feedTypeParameter": {
+      "name": "feedType",
+      "in": "path",
+      "required": "true",
+      "type": "string",
+      "format": "FeedType"
+    },
+    "credentialParameter": {
+      "name": "x-BeezUP-Credential",
+      "in": "header",
+      "required": "true",
+      "type": "string",
+      "description": "It's the merchant configuration related to the marketplace, serialiazed in json in base64."
+    }
+  },
+  "paths": {
+    "/{marketplaceBusinessCode}/ping": {
+      "post": {
+        "tags": [
+          "Publication"
+        ],
+        "summary": "Ping the status of your feed system",
+        "operationId": "PingGatewayFeedApi",
+        "parameters": [
+          {
+            "$ref": "#/parameters/marketplaceBusinessCodeParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The status of the API is up!"
+          },
+          "503": {
+            "description": "The status of your API is down..."
+          },
+          "default": {
+            "$ref": "#/responses/GeneralError"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Publication"
+        ],
+        "summary": "Fake the status of your feed system",
+        "operationId": "Fake",
+        "parameters": [
+          {
+            "$ref": "#/parameters/marketplaceBusinessCodeParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The status of the API is up!"
+          }
+        }
+      }
+    },
+    "/{marketplaceBusinessCode}/{accountId}/publications/{publicationId}/start": {
+      "post": {
+        "tags": [
+          "Publication"
+        ],
+        "summary": "Start the feed publication",
+        "operationId": "StartFeedPublication",
+        "parameters": [
+          {
+            "$ref": "#/parameters/marketplaceBusinessCodeParameter"
+          },
+          {
+            "$ref": "#/parameters/accountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/publicationIdParameter"
+          },
+          {
+            "$ref": "#/parameters/credentialParameter"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "required": "true",
+            "schema": {
+              "$ref": "#/definitions/startFeedPublicationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The merchant feeds changes have been saved!"
+          },
+          "default": {
+            "$ref": "#/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/{marketplaceBusinessCode}/{accountId}/publications/{publicationId}/complete": {
+      "post": {
+        "tags": [
+          "Publication"
+        ],
+        "summary": "Complete the feed publication",
+        "operationId": "CompleteFeedPublication",
+        "parameters": [
+          {
+            "$ref": "#/parameters/marketplaceBusinessCodeParameter"
+          },
+          {
+            "$ref": "#/parameters/accountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/publicationIdParameter"
+          },
+          {
+            "$ref": "#/parameters/credentialParameter"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "required": "true",
+            "schema": {
+              "$ref": "#/definitions/completeFeedPublicationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "The merchant feeds changes have been saved!"
+          },
+          "default": {
+            "$ref": "#/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/{marketplaceBusinessCode}/{accountId}/publications/{publicationId}/events": {
+      "post": {
+        "tags": [
+          "Publication"
+        ],
+        "summary": "Push a batch of merchant marketplace feeds events",
+        "operationId": "PushMerchantFeedEvents",
+        "parameters": [
+          {
+            "$ref": "#/parameters/marketplaceBusinessCodeParameter"
+          },
+          {
+            "$ref": "#/parameters/accountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/publicationIdParameter"
+          },
+          {
+            "$ref": "#/parameters/credentialParameter"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/feedEvents"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "The merchant feeds changes have been saved!"
+          },
+          "default": {
+            "$ref": "#/responses/GeneralError"
+          }
+        }
+      }
+    },
+    "/{marketplaceBusinessCode}/{accountId}/publications/{publicationId}/status": {
+      "get": {
+        "tags": [
+          "Publication"
+        ],
+        "x-tagGroups": "Publication",
+        "operationId": "CheckPublicationStatus",
+        "summary": "Check the status of the publication",
+        "parameters": [
+          {
+            "$ref": "#/parameters/marketplaceBusinessCodeParameter"
+          },
+          {
+            "$ref": "#/parameters/accountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/publicationIdParameter"
+          },
+          {
+            "$ref": "#/parameters/credentialParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Publication status retrieved",
+            "schema": {
+              "$ref": "#/definitions/feedPublicationStatusResponse"
+            }
+          },
+          "409": {
+            "description": "Publication status not yet available"
+          }
+        }
+      }
+    },
+    "/{marketplaceBusinessCode}/{accountId}/publications/{publicationId}/errorReporting": {
+      "get": {
+        "tags": [
+          "Publication"
+        ],
+        "x-tagGroups": "Publication",
+        "operationId": "GetPublicationErrorReporting",
+        "summary": "Get the error reporting of the publication",
+        "parameters": [
+          {
+            "$ref": "#/parameters/marketplaceBusinessCodeParameter"
+          },
+          {
+            "$ref": "#/parameters/accountIdParameter"
+          },
+          {
+            "$ref": "#/parameters/publicationIdParameter"
+          },
+          {
+            "$ref": "#/parameters/credentialParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The error reporting is retrieved",
+            "schema": {
+              "$ref": "#/definitions/feedPublicationErrorReportingResponse"
+            }
+          },
+          "409": {
+            "description": "Error reporting not yet available"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "startFeedPublicationRequest": {
+      "type": "object",
+      "required": [
+        "feedType"
+      ],
+      "properties": {
+        "feedType": {
+          "$ref": "#/definitions/feedType"
+        }
+      }
+    },
+    "completeFeedPublicationRequest": {
+      "type": "object",
+      "required": [
+        "processingStatus"
+      ],
+      "properties": {
+        "processingStatus": {
+          "$ref": "#/definitions/processingStatus"
+        },
+        "rollbarId": {
+          "type": "string"
+        },
+        "errorMsg": {
+          "type": "string"
+        }
+      }
+    },
+    "feedEvents": {
+      "type": "object",
+      "properties": {
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/feedEvent"
+          }
+        }
+      }
+    },
+    "feedPublicationStatusResponse": {
+      "description": "Publication Status Response",
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/feedPublicationStatus"
+        }
+      }
+    },
+    "feedPublicationErrorReportingResponse": {
+      "description": "Publication Error Reporting Response",
+      "type": "object",
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/feedPublicationError"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/feedPublicationError"
+          }
+        }
+      }
+    },
+    "BeezUP.Common.ErrorResponseMessage": {
+      "type": "object",
+      "required": [
+        "errors"
+      ],
+      "properties": {
+        "errors": {
+          "type": "array",
+          "uniqueItems": "false",
+          "items": {
+            "$ref": "#/definitions/BeezUP.Common.UserErrorMessage"
+          }
+        }
+      }
+    },
+    "BeezUP.Common.PageSize": {
+      "description": "Indicate the item count per page",
+      "type": "integer",
+      "format": "int32",
+      "default": "100",
+      "minimum": "25",
+      "maximum": "100",
+      "example": "100"
+    },
+    "BeezUP.Common.PageNumber": {
+      "description": "Indicates the page number",
+      "format": "int32",
+      "type": "integer",
+      "example": "1",
+      "minimum": "1",
+      "default": "1"
+    },
+    "BeezUP.Common.AdditionalProductFilters": {
+      "type": "object",
+      "description": "Describe a filter on a product's column.\nThe key is the column identifier of your catalog or a custom column.\n",
+      "additionalProperties": {
+        "$ref": "#/definitions/BeezUP.Common.AdditionalProductFiltersValue"
+      }
+    },
+    "BeezUP.Common.ProductColumnFilterOperatorName": {
+      "type": "string",
+      "description": "Indicate the operator you want to make on the columnId",
+      "x-lov": "ProductColumnFilterOperatorName"
+    },
+    "BeezUP.Common.AdditionalProductFiltersValue": {
+      "type": "object",
+      "properties": {
+        "operatorName": {
+          "$ref": "#/definitions/BeezUP.Common.ProductColumnFilterOperatorName"
+        },
+        "values": {
+          "description": "Must be null if the operator is \"IsNull\" or \"IsNotNull\".\nCan contains multiple value in case of \"InList\" operator. Otherwise a single value is expected.\n",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "My value"
+          ]
+        }
+      },
+      "example": {
+        "672644c7-5bd0-4e25-88c1-1f732bda5e4c": {
+          "operatorName": "GreaterTo",
+          "values": [
+            "100"
+          ]
+        }
+      }
+    },
+    "BeezUP.Common.ChannelId": {
+      "type": "string",
+      "format": "guid",
+      "description": "The channel identifier",
+      "example": "2dc136a7-0d3d-4cc9-a825-a28a42c53e28"
+    },
+    "BeezUP.Common.ChannelName": {
+      "type": "string",
+      "description": "The channel name",
+      "example": "Amazon FRA"
+    },
+    "BeezUP.Common.HttpUrl": {
+      "description": "The URL <a href=\"https://en.wikipedia.org/wiki/URL\">https://en.wikipedia.org/wiki/URL</a>",
+      "type": "string",
+      "pattern": "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$",
+      "example": "http://www.mydomain.com"
+    },
+    "BeezUP.Common.PaginationResultLinks": {
+      "description": "The navigation links 'first', 'last', 'next', 'previous'",
+      "type": "object",
+      "required": [
+        "first",
+        "last"
+      ],
+      "properties": {
+        "first": {
+          "$ref": "#/definitions/BeezUP.Common.Link3"
+        },
+        "last": {
+          "$ref": "#/definitions/BeezUP.Common.Link3"
+        },
+        "previous": {
+          "$ref": "#/definitions/BeezUP.Common.Link3"
+        },
+        "next": {
+          "$ref": "#/definitions/BeezUP.Common.Link3"
+        }
+      }
+    },
+    "BeezUP.Common.Link3": {
+      "type": "object",
+      "required": [
+        "href"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label corresponding to the link. This label is automatically translated based on the Accept-Language http header.",
+          "example": "The translated label"
+        },
+        "docUrl": {
+          "$ref": "#/definitions/BeezUP.Common.DocUrl"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the link",
+          "example": "This is a description link"
+        },
+        "href": {
+          "$ref": "#/definitions/BeezUP.Common.Href"
+        },
+        "operationId": {
+          "$ref": "#/definitions/BeezUP.Common.OperationId"
+        },
+        "method": {
+          "$ref": "#/definitions/BeezUP.Common.HttpMethod"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/BeezUP.Common.LinkParameter3"
+          }
+        },
+        "urlTemplated": {
+          "type": "boolean",
+          "description": "indicates whether the href is templated or not"
+        },
+        "allRequiredParamsProvided": {
+          "type": "boolean",
+          "description": "indicates whether all required params have been provided"
+        },
+        "allOptionalParamsProvided": {
+          "type": "boolean",
+          "description": "indicates whether all optionals params have been provided"
+        },
+        "info": {
+          "$ref": "#/definitions/BeezUP.Common.InfoSummaries"
+        }
+      }
+    },
+    "BeezUP.Common.DocUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "The documentation related to this operation.",
+      "example": "https://api-docs.beezup.com/#operation/EnableChannelCatalog"
+    },
+    "BeezUP.Common.Href": {
+      "type": "string",
+      "example": "/v2/marketplaces/orders/{marketplaceTechnicalCode}/{accountId}/{beezUPOrderId}",
+      "description": "Indicate the relative uri for this link"
+    },
+    "BeezUP.Common.OperationId": {
+      "type": "string",
+      "description": "The operationId to call.",
+      "example": "GetOrder"
+    },
+    "BeezUP.Common.HttpMethod": {
+      "type": "string",
+      "enum": [
+        "GET",
+        "POST",
+        "PATCH",
+        "DELETE",
+        "PUT",
+        "HEAD"
+      ],
+      "default": "GET",
+      "example": "GET",
+      "description": "Indicate the http method to use on this link"
+    },
+    "BeezUP.Common.LinkParameter3": {
+      "type": "object",
+      "required": [
+        "in"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label corresponding to the link parameter. This label is automatically translated based on the Accept-Language http header.",
+          "example": "The translated label"
+        },
+        "value": {
+          "type": "object",
+          "description": "The value of the parameter. It can be an integer a string or an object.",
+          "example": "1234"
+        },
+        "required": {
+          "type": "boolean",
+          "default": "false",
+          "example": "true"
+        },
+        "in": {
+          "$ref": "#/definitions/BeezUP.Common.ParameterIn"
+        },
+        "type": {
+          "$ref": "#/definitions/BeezUP.Common.ParameterType"
+        },
+        "lovLink": {
+          "$ref": "#/definitions/BeezUP.Common.LOVLink3"
+        },
+        "lovRequired": {
+          "type": "boolean",
+          "description": "If true, you MUST indicate a value from the list of values otherwise it's a freetext",
+          "example": "true"
+        },
+        "description": {
+          "type": "string",
+          "description": "description of the parameter",
+          "example": "the store identifier"
+        },
+        "schema": {
+          "type": "string",
+          "description": "schema of the parameter",
+          "example": "orderListRequest"
+        },
+        "properties": {
+          "description": "If the parameter is an object with flexible properties (additionProperties/dictionary), we will describe the properties of the object.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/BeezUP.Common.LinkParameterProperty3"
+          },
+          "example": {
+            "shipOrder": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "BeezUP.Common.InfoSummaries": {
+      "type": "object",
+      "properties": {
+        "successes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BeezUP.Common.SuccessSummary"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BeezUP.Common.ErrorSummary"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BeezUP.Common.WarningSummary"
+          }
+        },
+        "informations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BeezUP.Common.InfoSummary"
+          }
+        }
+      }
+    },
+    "BeezUP.Common.LinkParameter2": {
+      "type": "object",
+      "x-deprecated": "true",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter",
+          "example": "marketplaceTechnicalCode"
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the parameter",
+          "example": "1234"
+        },
+        "required": {
+          "type": "boolean",
+          "example": "true"
+        },
+        "in": {
+          "$ref": "#/definitions/BeezUP.Common.ParameterIn"
+        },
+        "type": {
+          "$ref": "#/definitions/BeezUP.Common.ParameterType"
+        },
+        "lovLink": {
+          "description": "This parameter expect the values indicated in this list of values.",
+          "$ref": "#/definitions/BeezUP.Common.LOVLink2"
+        },
+        "lovRequired": {
+          "type": "boolean",
+          "description": "If true, you MUST use indicate a value from the list of values otherwise it's a freetext",
+          "example": "true"
+        }
+      }
+    },
+    "BeezUP.Common.ParameterIn": {
+      "type": "string",
+      "description": "* path: if the parameter must be pass in the path uri\n* header: if the parameter must be passed in http header\n* query: if the parameter must be passed in querystring\n* body: if the paramter must be passed in the body\n",
+      "example": "path",
+      "enum": [
+        "path",
+        "header",
+        "query",
+        "body"
+      ]
+    },
+    "BeezUP.Common.ParameterType": {
+      "description": "The value type of the parameter",
+      "type": "string",
+      "enum": [
+        "string",
+        "integer",
+        "number",
+        "boolean",
+        "object",
+        "array",
+        "date",
+        "date-time"
+      ],
+      "default": "string",
+      "example": "string"
+    },
+    "BeezUP.Common.LOVLink3": {
+      "description": "Describe the way you have to follow to get access to the LOV",
+      "type": "object",
+      "required": [
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri",
+          "example": "/v2/public/Go2CultureName",
+          "description": "Indicate the uri to the list of value"
+        },
+        "method": {
+          "$ref": "#/definitions/BeezUP.Common.HttpMethod"
+        }
+      }
+    },
+    "BeezUP.Common.LinkParameterProperty3": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label corresponding to the link parameter property. This label is automatically translated based on the Accept-Language http header.",
+          "example": "The translated label"
+        },
+        "value": {
+          "type": "object",
+          "description": "The value of the parameter. It can be an integer a string or an object.",
+          "example": "1234"
+        },
+        "required": {
+          "type": "boolean",
+          "example": "true"
+        },
+        "type": {
+          "$ref": "#/definitions/BeezUP.Common.ParameterType"
+        },
+        "lovLink": {
+          "$ref": "#/definitions/BeezUP.Common.LOVLink3"
+        },
+        "lovRequired": {
+          "type": "boolean",
+          "description": "If true, you MUST use indicate a value from the list of values otherwise it's a freetext",
+          "example": "true"
+        },
+        "description": {
+          "type": "string",
+          "description": "description of the parameter",
+          "example": "the store identifier"
+        },
+        "schema": {
+          "type": "string",
+          "description": "schema of the parameter",
+          "example": "orderListRequest"
+        }
+      }
+    },
+    "BeezUP.Common.LOVLink2": {
+      "description": "Describe the way you have to follow to get access to the LOV",
+      "x-deprecated": "true",
+      "type": "object",
+      "required": [
+        "listName"
+      ],
+      "properties": {
+        "rel": {
+          "type": "string",
+          "description": "Indicate the relation name related to the link",
+          "example": "LOV_Go2CultureName"
+        },
+        "href": {
+          "type": "string",
+          "default": "/v2/user/{listName}",
+          "example": "/v2/public/{listName}",
+          "description": "Indicate the relative uri pattern to the list of value"
+        },
+        "listName": {
+          "type": "string",
+          "description": "The name of the list of value",
+          "example": "Go2CultureName"
+        }
+      }
+    },
+    "BeezUP.Common.UserErrorMessage": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "docUrl": {
+          "$ref": "#/definitions/BeezUP.Common.DocUrl"
+        },
+        "code": {
+          "type": "string",
+          "description": "the error code. The error code can be a pattern containing the argument's name",
+          "example": "CatalogImportationAlreadyInProgress(ExecutionId currentCatalogImportationId)"
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message",
+          "example": "There is already an importation in progress: b24d0dd8-a561-478a-9b26-34f573f03527\n"
+        },
+        "cultureName": {
+          "type": "string",
+          "description": "If the error is translated, the culture name will be indicated",
+          "example": "en",
+          "x-lov": "Go2CultureName"
+        },
+        "arguments": {
+          "type": "array",
+          "description": "a dictionary string/object",
+          "items": {
+            "type": "object",
+            "required": [
+              "name",
+              "value"
+            ],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "The key of the parameter",
+                "example": "currentCatalogImportationId"
+              },
+              "value": {
+                "type": "object",
+                "description": "The value of the parameter. Depending to the type.",
+                "example": "b24d0dd8-a561-478a-9b26-34f573f03527"
+              }
+            }
+          }
+        }
+      }
+    },
+    "BeezUP.Common.SuccessSummary": {
+      "type": "object",
+      "properties": {
+        "successCode": {
+          "type": "string"
+        },
+        "successMessage": {
+          "type": "string"
+        },
+        "successArguments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "propertyName": {
+          "type": "string"
+        },
+        "propertyValue": {
+          "type": "string"
+        },
+        "objectName": {
+          "type": "string"
+        }
+      }
+    },
+    "BeezUP.Common.ErrorSummary": {
+      "type": "object",
+      "properties": {
+        "utcDate": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "errorGuid": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "errorCode": {
+          "type": "string"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "technicalErrorMessage": {
+          "type": "string"
+        },
+        "exceptionDetail": {
+          "$ref": "#/definitions/BeezUP.Common.ExceptionDetail"
+        },
+        "errorArguments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "propertyName": {
+          "type": "string"
+        },
+        "propertyValue": {
+          "type": "string"
+        },
+        "objectName": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      }
+    },
+    "BeezUP.Common.WarningSummary": {
+      "type": "object",
+      "properties": {
+        "technicalErrorMessage": {
+          "type": "string"
+        },
+        "warningMessage": {
+          "type": "string"
+        },
+        "warningCode": {
+          "type": "string"
+        },
+        "warningArguments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "BeezUP.Common.InfoSummary": {
+      "type": "object",
+      "properties": {
+        "informationCode": {
+          "type": "string"
+        },
+        "informationMessage": {
+          "type": "string"
+        },
+        "informationArguments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "propertyName": {
+          "type": "string"
+        },
+        "propertyValue": {
+          "type": "string"
+        },
+        "objectName": {
+          "type": "string"
+        }
+      }
+    },
+    "BeezUP.Common.ExceptionDetail": {
+      "type": "object",
+      "properties": {
+        "helpLink": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "stackTrace": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "BeezUP.Common.ApiCredential": {
+      "description": "Your api credential",
+      "type": "object",
+      "properties": {
+        "productName": {
+          "description": "The product name related to this credential",
+          "type": "string",
+          "example": "UserAPI"
+        },
+        "primaryToken": {
+          "description": "The primary token to be used in the next call in the user scope API",
+          "type": "string",
+          "example": "3b22980d8d1143c6ba7adf4e55b9a153"
+        },
+        "secondaryToken": {
+          "description": "The secondary token. Could be usefull if you want to share your access with someone else.",
+          "type": "string",
+          "example": "162ae17fd52044c38cce3388ea5b0c91"
+        }
+      }
+    },
+    "processingStatus": {
+      "x-exclude": true,
+      "description": "The processing status of an operation",
+      "type": "string",
+      "enum": [
+        "none",
+        "inProgress",
+        "done",
+        "failed",
+        "aborted"
+      ]
+    },
+    "feedType": {
+      "type": "string",
+      "enum": [
+        "Product",
+        "Offer"
+      ]
+    },
+    "feedEvent": {
+      "type": "object",
+      "discriminator": "eventType",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/sku"
+        },
+        "eventType": {
+          "type": "string"
+        }
+      }
+    },
+    "sku": {
+      "type": "string",
+      "description": "The Stock Keeping Unit (SKU), i.e. a merchant-specific identifier for a product or service, or the product to which the offer refers. http://schema.org/sku",
+      "maxLength": "50"
+    },
+    "feedMetadata": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The marketplace column name"
+        },
+        "value": {
+          "type": "string"
+        }
+      }
+    },
+    "feedPublicationStatus": {
+      "type": "string",
+      "enum": [
+        "NotStarted",
+        "InProgress",
+        "Success",
+        "Failed"
+      ],
+      "default": "NotStarted"
+    },
+    "feedPublicationError": {
+      "type": "object",
+      "required": [
+        "code",
+        "count",
+        "skuList"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "skuList": {
+          "type": "array",
+          "minItems": "1",
+          "items": {
+            "$ref": "#/definitions/sku"
+          }
+        }
+      }
+    },
+    "errorResponseMessage": {
+      "x-exclude": true,
+      "type": "object",
+      "required": [
+        "errors"
+      ],
+      "properties": {
+        "errors": {
+          "type": "array",
+          "uniqueItems": "false",
+          "items": {
+            "$ref": "#/definitions/userErrorMessage"
+          }
+        }
+      }
+    },
+    "userErrorMessage": {
+      "x-exclude": true,
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "docUrl": {
+          "$ref": "#/definitions/docUrl"
+        },
+        "code": {
+          "$ref": "#/definitions/errorCode"
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message",
+          "example": "There is already an importation in progress: b24d0dd8-a561-478a-9b26-34f573f03527\n"
+        },
+        "cultureName": {
+          "$ref": "#/definitions/cultureName"
+        },
+        "arguments": {
+          "$ref": "#/definitions/userErrorMessageArguments"
+        }
+      }
+    },
+    "pageSize": {
+      "x-exclude": true,
+      "description": "Indicate the item count per page",
+      "type": "integer",
+      "format": "int32",
+      "default": "100",
+      "minimum": "25",
+      "x-minimum": "25",
+      "maximum": "100",
+      "x-maximum": "100",
+      "example": "100"
+    },
+    "pageNumber": {
+      "x-exclude": true,
+      "description": "Indicates the page number",
+      "format": "int32",
+      "type": "integer",
+      "example": "1",
+      "minimum": "1",
+      "x-minimum": "1",
+      "default": "1"
+    },
+    "paginationResultLinks": {
+      "x-exclude": true,
+      "description": "The navigation links 'first', 'last', 'next', 'previous'",
+      "type": "object",
+      "required": [
+        "first",
+        "last"
+      ],
+      "properties": {
+        "first": {
+          "$ref": "#/definitions/link3"
+        },
+        "last": {
+          "$ref": "#/definitions/link3"
+        },
+        "previous": {
+          "$ref": "#/definitions/link3"
+        },
+        "next": {
+          "$ref": "#/definitions/link3"
+        }
+      }
+    },
+    "link3": {
+      "x-exclude": true,
+      "type": "object",
+      "required": [
+        "href"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label corresponding to the link. This label is automatically translated based on the Accept-Language http header.",
+          "example": "The translated label"
+        },
+        "docUrl": {
+          "$ref": "#/definitions/docUrl"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the link",
+          "example": "This is a description link"
+        },
+        "href": {
+          "$ref": "#/definitions/href"
+        },
+        "operationId": {
+          "$ref": "#/definitions/operationId"
+        },
+        "method": {
+          "$ref": "#/definitions/httpMethod"
+        },
+        "parameters": {
+          "$ref": "#/definitions/linkParameter3Types"
+        },
+        "urlTemplated": {
+          "type": "boolean",
+          "description": "indicates whether the href is templated or not"
+        },
+        "allRequiredParamsProvided": {
+          "type": "boolean",
+          "description": "indicates whether all required params have been provided"
+        },
+        "allOptionalParamsProvided": {
+          "type": "boolean",
+          "description": "indicates whether all optionals params have been provided"
+        },
+        "info": {
+          "$ref": "#/definitions/infoSummaries"
+        }
+      }
+    },
+    "docUrl": {
+      "x-exclude": true,
+      "type": "string",
+      "format": "uri",
+      "description": "The documentation related to this operation.",
+      "example": "https://api-docs.imn.io/#operation/EnableChannelCatalog"
+    },
+    "href": {
+      "x-exclude": true,
+      "type": "string",
+      "example": "/merchant/orders/v1/{marketplaceCode}/{IMNOrderId}",
+      "description": "Indicate the relative uri for this link"
+    },
+    "operationId": {
+      "x-exclude": true,
+      "type": "string",
+      "description": "The operationId to call.",
+      "example": "GetOrder"
+    },
+    "httpMethod": {
+      "x-exclude": true,
+      "type": "string",
+      "enum": [
+        "GET",
+        "POST",
+        "PATCH",
+        "DELETE",
+        "PUT",
+        "HEAD"
+      ],
+      "default": "GET",
+      "example": "GET",
+      "description": "Indicate the http method to use on this link"
+    },
+    "linkParameter3Types": {
+      "x-exclude": true,
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/linkParameter3"
+      }
+    },
+    "infoSummaries": {
+      "type": "object",
+      "properties": {
+        "successes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/successSummary"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/errorSummary"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/warningSummary"
+          }
+        },
+        "informations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/infoSummary"
+          }
+        }
+      }
+    },
+    "linkParameter3": {
+      "x-exclude": true,
+      "type": "object",
+      "required": [
+        "in"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label corresponding to the link parameter. This label is automatically translated based on the Accept-Language http header.",
+          "example": "The translated label"
+        },
+        "value": {
+          "type": "object",
+          "description": "The value of the parameter. It can be an integer a string or an object.",
+          "example": "1234"
+        },
+        "required": {
+          "type": "boolean",
+          "default": "false",
+          "example": "true"
+        },
+        "in": {
+          "$ref": "#/definitions/parameterIn"
+        },
+        "lovLink": {
+          "$ref": "#/definitions/LOVLink3"
+        },
+        "lovRequired": {
+          "type": "boolean",
+          "description": "If true, you MUST indicate a value from the list of values otherwise it's a freetext",
+          "example": "true"
+        },
+        "description": {
+          "type": "string",
+          "description": "description of the parameter",
+          "example": "the store identifier"
+        },
+        "schema": {
+          "type": "string",
+          "description": "schema of the parameter",
+          "example": "orderListRequest"
+        },
+        "pattern": {
+          "$ref": "#/definitions/validationPattern"
+        },
+        "properties": {
+          "description": "If the parameter is an object with flexible properties (additionProperties/dictionary), we will describe the properties of the object.",
+          "additionalProperties": {
+            "$ref": "#/definitions/linkParameterProperty3"
+          },
+          "example": {
+            "shipOrder": {
+              "type": "​string"
+            }
+          }
+        }
+      }
+    },
+    "parameterIn": {
+      "x-exclude": true,
+      "type": "string",
+      "description": "* path: if the parameter must be pass in the path uri\n* header: if the parameter must be passed in http header\n* query: if the parameter must be passed in querystring\n* body: if the parameter must be passed in the body\n* file: if the parameter must be passed in a multipart/form-data (https://swagger.io/docs/specification/2-0/file-upload/)\n",
+      "example": "path",
+      "enum": [
+        "path",
+        "header",
+        "query",
+        "body",
+        "file"
+      ]
+    },
+    "LOVLink3": {
+      "x-exclude": true,
+      "description": "Describe the way you have to follow to get access to the LOV",
+      "type": "object",
+      "required": [
+        "href"
+      ],
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri",
+          "example": "/merchant/lov/v1/Go2CultureName",
+          "description": "Indicate the uri to the list of value"
+        },
+        "method": {
+          "$ref": "#/definitions/httpMethod"
+        }
+      }
+    },
+    "validationPattern": {
+      "type": "string",
+      "description": "The regular expression to validate the value",
+      "example": "*.-api$"
+    },
+    "linkParameterProperty3": {
+      "x-exclude": true,
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "description": "The label corresponding to the link parameter property. This label is automatically translated based on the Accept-Language http header.",
+          "example": "The translated label"
+        },
+        "value": {
+          "type": "object",
+          "description": "The value of the parameter. It can be an integer a string or an object.",
+          "example": "1234"
+        },
+        "required": {
+          "type": "boolean",
+          "example": "true"
+        },
+        "type": {
+          "$ref": "#/definitions/parameterType"
+        },
+        "lovLink": {
+          "$ref": "#/definitions/LOVLink3"
+        },
+        "lovRequired": {
+          "type": "boolean",
+          "description": "If true, you MUST use indicate a value from the list of values otherwise it's a freetext",
+          "example": "true"
+        },
+        "description": {
+          "type": "string",
+          "description": "description of the parameter",
+          "example": "the store identifier"
+        },
+        "schema": {
+          "type": "string",
+          "description": "schema of the parameter",
+          "example": "orderListRequest"
+        },
+        "pattern": {
+          "$ref": "#/definitions/validationPattern"
+        }
+      }
+    },
+    "parameterType": {
+      "x-exclude": true,
+      "description": "The value type of the parameter",
+      "type": "string",
+      "enum": [
+        "string",
+        "integer",
+        "number",
+        "boolean",
+        "object",
+        "array",
+        "date",
+        "date-time",
+        "file"
+      ],
+      "default": "string",
+      "example": "string"
+    },
+    "errorCode": {
+      "x-exclude": true,
+      "type": "string",
+      "description": "the error code. The error code can be a pattern containing the argument's name",
+      "example": "CatalogImportationAlreadyInProgress(ExecutionId currentCatalogImportationId)"
+    },
+    "cultureName": {
+      "x-exclude": true,
+      "type": "string",
+      "description": "If the error is translated, the culture name will be indicated",
+      "example": "en",
+      "x-lov": "Go2CultureName"
+    },
+    "userErrorMessageArguments": {
+      "x-exclude": true,
+      "type": "object",
+      "description": "a dictionary string/object",
+      "additionalProperties": {
+        "type": "object"
+      }
+    },
+    "successSummary": {
+      "type": "object",
+      "properties": {
+        "successCode": {
+          "type": "string"
+        },
+        "successMessage": {
+          "type": "string"
+        },
+        "successArguments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "propertyName": {
+          "type": "string"
+        },
+        "propertyValue": {
+          "type": "string"
+        },
+        "objectName": {
+          "type": "string"
+        }
+      }
+    },
+    "errorSummary": {
+      "type": "object",
+      "properties": {
+        "utcDate": {
+          "format": "date-time",
+          "type": "string"
+        },
+        "errorGuid": {
+          "format": "uuid",
+          "type": "string"
+        },
+        "errorCode": {
+          "type": "string"
+        },
+        "errorMessage": {
+          "type": "string"
+        },
+        "technicalErrorMessage": {
+          "type": "string"
+        },
+        "exceptionDetail": {
+          "$ref": "#/definitions/exceptionDetail"
+        },
+        "errorArguments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "propertyName": {
+          "type": "string"
+        },
+        "propertyValue": {
+          "type": "string"
+        },
+        "objectName": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        }
+      }
+    },
+    "warningSummary": {
+      "type": "object",
+      "properties": {
+        "technicalErrorMessage": {
+          "type": "string"
+        },
+        "warningMessage": {
+          "type": "string"
+        },
+        "warningCode": {
+          "type": "string"
+        },
+        "warningArguments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "infoSummary": {
+      "type": "object",
+      "properties": {
+        "informationCode": {
+          "type": "string"
+        },
+        "informationMessage": {
+          "type": "string"
+        },
+        "informationArguments": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "propertyName": {
+          "type": "string"
+        },
+        "propertyValue": {
+          "type": "string"
+        },
+        "objectName": {
+          "type": "string"
+        }
+      }
+    },
+    "exceptionDetail": {
+      "type": "object",
+      "properties": {
+        "helpLink": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "stackTrace": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "merchantCode": {
+      "type": "string",
+      "description": "The merchant code identifier in IMN",
+      "pattern": "^([A-Z|0-9]){5}$",
+      "x-pattern": "^([A-Z|0-9]){5}$",
+      "example": "MLT01"
+    },
+    "marketplaceCode": {
+      "type": "string",
+      "description": "The marketplace code identifier in IMN.\nFor now we have:\n- C1 for Cdiscount\n- E1 for ePrice\n- R1 for Real.DE\n- B1 for BOL\n- E2 for eMAG\n",
+      "pattern": "^([A-Z]|[0-9]){2}$",
+      "x-pattern": "^([A-Z]|[0-9]){2}$",
+      "example": "C1"
+    },
+    "healthCheckStatus": {
+      "type": "string",
+      "description": "Possible status values of a health check result.\n* degraded:  The check is degraded, failing but not critical\n* healthy: The check is healthy\n* ignored: The check was ignored\n* unhealthy:  The check is unhealthy\n",
+      "enum": [
+        "degraded",
+        "healthy",
+        "ignored",
+        "unhealthy"
+      ]
+    },
+    "messageId": {
+      "x-exclude": true,
+      "description": "The message identifier. It's a guid.",
+      "format": "MessageId",
+      "type": "string",
+      "example": "b0d3faea-f881-439f-ba92-02b1168511ea"
+    },
+    "correlationId": {
+      "x-exclude": true,
+      "description": "The correlation identifier. It's a guid.",
+      "format": "CorrelationId",
+      "type": "string",
+      "example": "b0d3faea-f881-439f-ba92-02b1168511ea"
+    },
+    "causeId": {
+      "x-exclude": true,
+      "description": "The cause identifier. It's a guid.",
+      "format": "CauseId",
+      "type": "string",
+      "example": "b0d3faea-f881-439f-ba92-02b1168511ea"
+    },
+    "messageBase": {
+      "x-exclude": true,
+      "type": "object",
+      "required": [
+        "messageId",
+        "correlationId"
+      ],
+      "properties": {
+        "messageId": {
+          "allOf": [
+            {
+              "x-excludeProperty": "true"
+            },
+            {
+              "$ref": "#/definitions/messageId"
+            }
+          ]
+        },
+        "correlationId": {
+          "$ref": "#/definitions/correlationId"
+        },
+        "causeId": {
+          "$ref": "#/definitions/causeId"
+        }
+      }
+    },
+    "eventType": {
+      "x-exclude": true,
+      "description": "The event type",
+      "type": "string"
+    }
+  },
+  "x-azure-api-id": "MarketplaceGatewayFeedsV1",
+  "responses": {
+    "GeneralError": {
+      "description": "Occurs when something goes wrong",
+      "schema": {
+        "$ref": "#/definitions/BeezUP.Common.ErrorResponseMessage"
+      }
+    }
+  }
+}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/template1/path1.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/template1/path1.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_path1.cs
+//{{split_get_last @key '/'}}_path1
+{{/each}}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test3/template2/path2.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test3/template2/path2.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_paths2.cs
+//{{split_get_last @key '/'}}_path2
+{{/each}}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test4/template1/path1.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test4/template1/path1.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_path1.cs
+//{{split_get_last @key '/'}}_path1
+{{/each}}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test4/template1/path2.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test4/template1/path2.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_paths2.cs
+//{{split_get_last @key '/'}}_path2
+{{/each}}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test4/template2/path1.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test4/template2/path1.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_path1.cs
+//{{split_get_last @key '/'}}_path1
+{{/each}}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test4/template2/path2.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test4/template2/path2.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_paths2.cs
+//{{split_get_last @key '/'}}_path2
+{{/each}}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test4/template3/path3.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test4/template3/path3.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_paths3.cs
+//{{split_get_last @key '/'}}_path3
+{{/each}}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test4/template3/path4.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test4/template3/path4.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_paths4.cs
+//{{split_get_last @key '/'}}_path4
+{{/each}}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test4/template4/path3.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test4/template4/path3.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_paths3.cs
+//{{split_get_last @key '/'}}_path3
+{{/each}}

--- a/tests/Dotnet.CodeGen.Tests/_samples/test4/template4/path4.hbs
+++ b/tests/Dotnet.CodeGen.Tests/_samples/test4/template4/path4.hbs
@@ -1,0 +1,4 @@
+{{#each paths}}
+### FILE {{split_get_last @key '/'}}_paths4.cs
+//{{split_get_last @key '/'}}_path4
+{{/each}}


### PR DESCRIPTION
https://github.com/BeezUP/dotnet-codegen/issues/3

The template folder/file argument allow now multiple folders/files. There is a new options to choose a duplicate template strategy (throw, choose first, choose last with throw as default).

The duplicated partials (i.e partials with same filename in different folder) usecase is not handled. I could add it in another PR.

It changes a little bit the api:
before => dotnet-codegen [SOURCE]  [TEMPLATE] [OUTPUT]
after => dotnet-codegen [SOURCE] [OUTPUT] [TEMPLATE1] [TEMPLATE2] [TEMPLATE3] [...]

with -d KeepFirst/KeepLast/Throw as a new option